### PR TITLE
add PyYAML to setup.py install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
     author='Mic Bowman, Intel Labs',
     url='http://www.intel.com',
     packages=find_packages(),
-    install_requires=['sawtooth-core', 'cbor>=0.1.23', 'colorlog'],
+    install_requires=['sawtooth-core', 'cbor>=0.1.23', 'colorlog', 'PyYAML'],
     entry_points={
         'console_scripts': [
             'mktclient = mktmain.client_cli:main'


### PR DESCRIPTION
`sawtooth-validator` requires `PyYAML` 

It is installed by `sawtooth-dev-tools` but was not included in the `install_requires` of `setup.py`
