### PR TITLE
Avoid UnicodeDecodeError when logging cbor string

### DIFF
--- a/mktplace/mktplace_communication.py
+++ b/mktplace/mktplace_communication.py
@@ -16,6 +16,7 @@
 A class to canonicalize communication with the marketplace
 """
 
+import base64
 import logging
 import urllib2
 
@@ -126,8 +127,8 @@ class MarketPlaceCommunication(object):
         datalen = len(data)
         url = self.BaseURL + msgtype
 
-        logger.debug('post transaction to %s with DATALEN=%d, DATA=<%s>', url,
-                     datalen, data)
+        logger.debug('post transaction to %s with DATALEN=%d, '
+                     'base64(DATA)=<%s>', url, datalen, base64.b64encode(data))
 
         try:
             request = urllib2.Request(url, data,


### PR DESCRIPTION
Signed-off-by: feihujiang jiangfeihu@huawei.com

Always got the following debug information:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/logging/__init__.py", line 851, in emit
    msg = self.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 724, in format
    return fmt.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 467, in format
    s = self._fmt % record.__dict__
UnicodeDecodeError: 'ascii' codec can't decode byte 0xa4 in position 112: ordinal not in range(128)
```

This information is annoying, this commit just fix it, now the debug information:

```
[15:38:10 mktplace.mktplace_communication DEBUG] post transaction to http://localhost:8800/mktplace.transactions.MarketPlace/Transaction with DATALEN=507, base64(DATA)=<pGtUcmFuc2FjdGlvbqVsRGVwZW5kZW5jaWVzgXA4YzU5Nzk3ZGJhNDEyYjg4ZU5vbmNl+0HV7a3YggPiaVNpZ25hdHVyZXhYSElEYUEzOHBqNEZpTkg4Z3VpbllLWkRjbHNMaEpTbzJUUkpxWmhRSG1UOW1KL3ZEUGVuQW1BMEhhYXpOZ1dydm1mSHRkSnBMRmR4Rndob2tuTnVFZnNnPW9UcmFuc2FjdGlvblR5cGV3L01hcmtldFBsYWNlVHJhbnNhY3Rpb25mVXBkYXRlpGlDcmVhdG9ySURwOGM1OTc5N2RiYTQxMmI4OGtEZXNjcmlwdGlvbmBkTmFtZW8vbWFya2V0L2FjY291bnRqVXBkYXRlVHlwZXgtL21rdHBsYWNlLnRyYW5zYWN0aW9ucy5BY2NvdW50VXBkYXRlL1JlZ2lzdGVyaV9fTk9OQ0VfX/tB1e2t2IKmBW1fX1NJR05BVFVSRV9feFhHL0RlV1NwWEhPREZzbWR4RXljeVBvQk8wOEtJQkdGUVRrbkpVRnBkM1NuNmhuWTlaa0JUMHpFQUppRXJlTVJ4d1lZWDJOdElJTXNJWkwxRy9vYUxvajA9aF9fVFlQRV9feC4vbWt0cGxhY2UudHJhbnNhY3Rpb25zLk1hcmtldFBsYWNlL1RyYW5zYWN0aW9u>
```
